### PR TITLE
Tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 package-lock.json
 .env
 yarn.lock
+coverage

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  // Basic config
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/', '<rootDir>/public/'],
+  testEnvironment: 'jsdom',
+
+  // For handle with css files in tests
+  moduleNameMapper: {
+    "\\.(scss|css|sass)$": "identity-obj-proxy"
+  },
+
+  // For collect coverage
+  collectCoverage: true,
+  "collectCoverageFrom": [
+    "src/**/*.tsx",
+    "!src/**/*.spec.tsx",
+    "!src/**/*_app.tsx",
+    "!src/**/*_document.tsx"
+  ],
+  coverageReporters: ["lcov"],
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+
+// Mock the i18n service with version ^7.0.1 if the version changes this mock must change too
+jest.mock('next/config', () => {
+  return {
+    default: () => {
+      return {
+        publicRuntimeConfig: {
+          localeSubpaths: ['']
+        }
+      }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -38,11 +39,22 @@
     "react-tooltip": "^4.2.21"
   },
   "devDependencies": {
+    "@testing-library/dom": "^8.7.1",
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^12.1.1",
+    "@testing-library/user-event": "^13.2.1",
+    "@types/jest": "^27.0.2",
+    "@types/node": "^16.10.2",
     "@types/react": "^17.0.26",
     "autoprefixer": "^10.2.5",
+    "babel-jest": "^27.2.4",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^27.2.4",
     "postcss": "^8.3.0",
     "tailwindcss": "^2.2.7",
     "tailwindcss-typography": "^3.1.0",
+    "ts-jest": "^27.0.5",
+    "ts-node": "^10.2.1",
     "typescript": "^4.4.3"
   }
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,7 +1,7 @@
 import style from '../styles/components/footer.module.css'
 import i18n from '../services/i18n';
 
-export const Footer = ({t}) => {
+const Footer = ({t}) => {
   return (
     <footer className={style.footer}>
       <a href="https://github.com/ySnoopyDogy/MenheraBot" target="_blank" rel="noopener noreferrer">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,11 +1,11 @@
 import style from '../styles/components/footer.module.css'
 import i18n from '../services/i18n';
 
-const Footer = ({t}) => {
+export const Footer = ({t}) => {
   return (
     <footer className={style.footer}>
       <a href="https://github.com/ySnoopyDogy/MenheraBot" target="_blank" rel="noopener noreferrer">
-        {t('made')} <div id={style.heart}>❤️</div> {t('lux')}
+        {t('made')} <div id={style.heart} data-testid="emoji">❤️</div> {t('lux')}
         </a>
     </footer>
   )

--- a/src/tests/components/footer.spec.tsx
+++ b/src/tests/components/footer.spec.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+
+import { Footer } from '../../components/footer';
+
+describe('Footer component', () => {
+  it('Should be able to render correctly', () => {
+    const { getByTestId } = render(<Footer t={key => key} />);
+    const footer = getByTestId('emoji');
+
+    expect(footer).toBeTruthy();
+  });
+});

--- a/src/tests/components/footer.spec.tsx
+++ b/src/tests/components/footer.spec.tsx
@@ -1,10 +1,10 @@
 import { render } from "@testing-library/react";
 
-import { Footer } from '../../components/footer';
+import Footer from '../../components/footer';
 
 describe('Footer component', () => {
   it('Should be able to render correctly', () => {
-    const { getByTestId } = render(<Footer t={key => key} />);
+    const { getByTestId } = render(<Footer />);
     const footer = getByTestId('emoji');
 
     expect(footer).toBeTruthy();


### PR DESCRIPTION
Good afternoon people. @ySnoopyDogy 

I configured the tests by integrating Typescript, CSS, NextJS and collecting coverage, mocked the i18n service and created the first test for the footer component.

https://github.com/MenheraBot/MenheraSite/issues/30

There are two ways to test, the first one only tests the component without the i18n which was the way I did in the first commit, it doesn't take into account the:

```tsx
export default i18n.withTranslation('footer')(Footer)
```

The second way that I left tests the component the way it is used, but a warning is showing on the terminal.

<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/2b19e2fb-f438-410b-a497-9b1a7027270c/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20211002%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211002T191658Z&X-Amz-Expires=86400&X-Amz-Signature=15418e9472c8bd39492aaff7b909c90c48e868d98247f82eaef5190038fa0f74&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22" />

To clear this warning we need to update next-i18n and also integrate it to react-next-i18n.

https://react.i18next.com/misc/testing

This happens because only react-i18next has typed and mocks withTranslation, it's already installed as a third-party dependency, I didn't try to do this because it's already being done:

https://github.com/MenheraBot/MenheraSite/pull/22
https://github.com/MenheraBot/MenheraSite/issues/29
